### PR TITLE
Fixups to limitations in PR

### DIFF
--- a/pkg/adaptor/plugin.go
+++ b/pkg/adaptor/plugin.go
@@ -52,6 +52,7 @@ func AdaptPluginComponents(workspaceId, namespace string, devfileComponents []de
 		if config.ControllerCfg.GetExperimentalFeaturesEnabled() {
 			plugin_patch.PublicAccessPatch(&plugin)
 			plugin_patch.PatchMachineSelector(&plugin, workspaceId)
+			plugin_patch.AddMachineNameEnv(&plugin)
 		}
 
 		component, err := adaptChePluginToComponent(workspaceId, plugin)

--- a/pkg/adaptor/plugin.go
+++ b/pkg/adaptor/plugin.go
@@ -51,6 +51,7 @@ func AdaptPluginComponents(workspaceId, namespace string, devfileComponents []de
 	for _, plugin := range plugins {
 		if config.ControllerCfg.GetExperimentalFeaturesEnabled() {
 			plugin_patch.PublicAccessPatch(&plugin)
+			plugin_patch.PatchMachineSelector(&plugin, workspaceId)
 		}
 
 		component, err := adaptChePluginToComponent(workspaceId, plugin)

--- a/pkg/adaptor/plugin_patch/machine_exec_selector.go
+++ b/pkg/adaptor/plugin_patch/machine_exec_selector.go
@@ -1,0 +1,25 @@
+package plugin_patch
+
+import (
+	"fmt"
+	"github.com/eclipse/che-plugin-broker/model"
+)
+
+const (
+	podSelectorCmdLineArg = "--pod-selector"
+	podSelectorFmt        = "controller.devfile.io/workspace_id=%s"
+)
+
+// PatchMachineSelector overrides the pod selector used to find the workspace pod on the cluster, in order to
+// allow opening a terminal into the pod. This is required to enable compatability with existing plugin registries,
+// where the default value results in che-machine-exec attempting to use the `che.workspace_id` label.
+//
+// Function is a no-op if plugin is not named "che-machine-exec-plugin"
+func PatchMachineSelector(plugin *model.ChePlugin, workspaceId string) {
+	if plugin.Name != "che-machine-exec-plugin" {
+		return
+	}
+	for i, container := range plugin.Containers {
+		plugin.Containers[i].Command = append(container.Command, podSelectorCmdLineArg, fmt.Sprintf(podSelectorFmt, workspaceId))
+	}
+}

--- a/pkg/adaptor/plugin_patch/machine_name_env.go
+++ b/pkg/adaptor/plugin_patch/machine_name_env.go
@@ -1,0 +1,18 @@
+package plugin_patch
+
+import (
+	"github.com/eclipse/che-plugin-broker/model"
+)
+
+// AddMachineNameEnv Adds the environment variable CHE_MACHINE_NAME to a plugin, in order
+// to allow che-machine-exec to find the container within the workspace pod.
+//
+// Note this matching is fragile, as it is unclear how to handle aliases on components correctly.
+func AddMachineNameEnv(plugin *model.ChePlugin) {
+	for i, container := range plugin.Containers {
+		plugin.Containers[i].Env = append(container.Env, model.EnvVar{
+			Name:  "CHE_MACHINE_NAME",
+			Value: container.Name,
+		})
+	}
+}

--- a/pkg/adaptor/plugin_patch/public_access.go
+++ b/pkg/adaptor/plugin_patch/public_access.go
@@ -18,10 +18,10 @@ import (
 	"github.com/eclipse/che-plugin-broker/model"
 )
 
-//PublicAccessPatch pathes plugin's configuration to make endpoints publicly available
-//Plugins are configured to listen to only localhost only since they don't provide any authentication
+// PublicAccessPatch pathes plugin's configuration to make endpoints publicly available
+// Plugins are configured to listen to only localhost only since they don't provide any authentication
 // and their endpoint is supposed to be accessed though some proxy that provides authentication/authorization.
-//Since authentication is not solved for devworkspace endpoints, it's the workaround to make endpoints available somehow for testing
+// Since authentication is not solved for devworkspace endpoints, it's the workaround to make endpoints available somehow for testing
 func PublicAccessPatch(plugin *model.ChePlugin) {
 	if plugin.Name == "che-machine-exec-plugin" {
 		for _, value := range plugin.Containers {

--- a/pkg/controller/workspace/restapis/configmap.go
+++ b/pkg/controller/workspace/restapis/configmap.go
@@ -144,7 +144,7 @@ func constructRuntimeAnnotation(components []v1alpha1.ComponentDescription, endp
 
 func getMachinesAnnotation(components []v1alpha1.ComponentDescription, endpoints map[string]v1alpha1.ExposedEndpointList) map[string]v1alpha1.CheWorkspaceMachine {
 	machines := map[string]v1alpha1.CheWorkspaceMachine{}
-
+	machineRunningString := v1alpha1.RunningMachineEventType
 	for _, component := range components {
 		for containerName, container := range component.ComponentMetadata.Containers {
 			servers := map[string]v1alpha1.CheWorkspaceServer{}
@@ -159,6 +159,7 @@ func getMachinesAnnotation(components []v1alpha1.ComponentDescription, endpoints
 			machines[containerName] = v1alpha1.CheWorkspaceMachine{
 				Attributes: container.Attributes,
 				Servers:    servers,
+				Status:     &machineRunningString,
 			}
 		}
 	}


### PR DESCRIPTION
Commit-by-commit:
- Set running status for all components in the che api sidecar runtime JSON, to make all machines appear as running in the UI
- Add patch to set correct pod selector for `che-machine-exec` plugin. This is required in order to allow the plugin to find the correct workspace pod (it's hard-coded in the cloud-shell plugin, for example)
- Add patch to set `CHE_MACHINE_NAME` env var for plugin containers. This is required by che-machine-exec to find the correct container in a workspace pod.

The two patches are gated behind the experimental features config setting.